### PR TITLE
Provide support for masking HTML tags while editing

### DIFF
--- a/tmgmt_ckeditor.api.php.module
+++ b/tmgmt_ckeditor.api.php.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the TMGMT CKEditor module.
+ */
+
+use Drupal\tmgmt\JobItemInterface;
+
+/**
+ * Allows to alter a text's segment unmasking the HTML tags from a tmgmt-tag.
+ *
+ * @param string $text
+ *   The text's segment to alter.
+ * @param array $data_item
+ *   The data item.
+ * @param \Drupal\tmgmt\JobItemInterface $job_item
+ *   The job item context.
+ */
+function hook_tmgmt_data_item_text_output_alter(&$text, $data_item, JobItemInterface $job_item) {
+  $text = str_replace('First', 'Second', $text);
+}
+
+/**
+ * Allows to alter a text's segment masking the HTML tags into a tmgmt-tag.
+ *
+ * @param string $text
+ *   The text's segment to alter.
+ * @param array $data_item
+ *   The data item.
+ * @param \Drupal\tmgmt\JobItemInterface $job_item
+ *   The job item context.
+ */
+function hook_tmgmt_data_item_text_input_alter(&$text, $data_item, JobItemInterface $job_item) {
+  $text = str_replace('Second', 'First', $text);
+}

--- a/tmgmt_ckeditor_test/tmgmt_ckeditor_test.info.yml
+++ b/tmgmt_ckeditor_test/tmgmt_ckeditor_test.info.yml
@@ -1,0 +1,12 @@
+name: TMGMT CKEditor Test plugin
+type: module
+description: CKEditor test plugins for the translation UI
+core: 8.x
+package: CKEditor
+version: VERSION
+
+dependencies:
+ - tmgmt_memory
+ - tmgmt_demo
+ - paragraphs_demo
+ - tmgmt_ckeditor

--- a/tmgmt_ckeditor_test/tmgmt_ckeditor_test.module
+++ b/tmgmt_ckeditor_test/tmgmt_ckeditor_test.module
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Contains tmgmt_ckeditor_test.module.
+ */
+
+use Drupal\tmgmt\JobItemInterface;
+
+/**
+ * Implements hook_tmgmt_data_item_text_output_alter().
+ */
+function tmgmt_ckeditor_test_tmgmt_data_item_text_output_alter(&$text, $data_item, JobItemInterface $job_item) {
+  $text = str_replace('First', 'Second', $text);
+}
+
+/**
+ * Implements hook_tmgmt_data_item_text_input_alter().
+ */
+function tmgmt_ckeditor_test_tmgmt_data_item_text_input_alter(&$text, $data_item, JobItemInterface $job_item) {
+  $text = str_replace('Second', 'First', $text);
+}


### PR DESCRIPTION
From [d.o](https://www.drupal.org/node/2757813), we've started writing a patch to provide this feature.
Now here we will implement a real case with the actual HTML tags.

As first step, I've just added an initial alter hooks to mask TMGMT HTML tags in /tmgmt_ckeditor_test
